### PR TITLE
Add {float} <=> {integer} implementations

### DIFF
--- a/src/implements.rs
+++ b/src/implements.rs
@@ -28,12 +28,16 @@ macro_rules! approxeq_impl_ints {
         approxeq_impl_abs!($type, i64);
         approxeq_impl_abs!($type, i128);
         approxeq_impl_abs!($type, isize);
+
         approxeq_impl_abs!($type, u8);
         approxeq_impl_abs!($type, u16);
         approxeq_impl_abs!($type, u32);
         approxeq_impl_abs!($type, u64);
         approxeq_impl_abs!($type, u128);
         approxeq_impl_abs!($type, usize);
+
+        approxeq_impl_abs!($type, f32);
+        approxeq_impl_abs!($type, f64);
     }
 }
 
@@ -45,12 +49,23 @@ macro_rules! approxeq_impl_uints {
         approxeq_impl_no_abs!($type, i64);
         approxeq_impl_no_abs!($type, i128);
         approxeq_impl_no_abs!($type, isize);
+
         approxeq_impl_no_abs!($type, u8);
         approxeq_impl_no_abs!($type, u16);
         approxeq_impl_no_abs!($type, u32);
         approxeq_impl_no_abs!($type, u64);
         approxeq_impl_no_abs!($type, u128);
         approxeq_impl_no_abs!($type, usize);
+
+        approxeq_impl_no_abs!($type, f32);
+        approxeq_impl_no_abs!($type, f64);
+    }
+}
+
+macro_rules! approxeq_impl_floats {
+    ($type:ident) => {
+        approxeq_impl_abs!(f32, $type);
+        approxeq_impl_abs!(f64, $type);
     }
 }
 
@@ -67,7 +82,19 @@ approxeq_impl_uints!(u64);
 approxeq_impl_uints!(u128);
 approxeq_impl_uints!(usize);
 
-approxeq_impl_abs!(f32, f32);
-approxeq_impl_abs!(f32, f64);
-approxeq_impl_abs!(f64, f32);
-approxeq_impl_abs!(f64, f64);
+approxeq_impl_floats!(i8);
+approxeq_impl_floats!(i16);
+approxeq_impl_floats!(i32);
+approxeq_impl_floats!(i64);
+approxeq_impl_floats!(i128);
+approxeq_impl_floats!(isize);
+
+approxeq_impl_floats!(u8);
+approxeq_impl_floats!(u16);
+approxeq_impl_floats!(u32);
+approxeq_impl_floats!(u64);
+approxeq_impl_floats!(u128);
+approxeq_impl_floats!(usize);
+
+approxeq_impl_floats!(f32);
+approxeq_impl_floats!(f64);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 
-macro_rules! int_test {
+macro_rules! test {
     ($type1:ident, $type2:ident) => {{
-        let a: $type1 = 5;
-        let b: $type2 = 3;
-        let c: $type2 = 1;
+        let a = 5 as $type1;
+        let b = 3 as $type2;
+        let c = 1 as $type2;
         assert!(a.aeq(&b));
         assert!(a.nae(&c));
     }};
@@ -14,18 +14,46 @@ macro_rules! int_tests {
     ($type:ident) => {
         #[test]
         fn $type() {
-            int_test!($type, u8);
-            int_test!($type, u16);
-            int_test!($type, u32);
-            int_test!($type, u64);
-            int_test!($type, u128);
-            int_test!($type, usize);
-            int_test!($type, i8);
-            int_test!($type, i16);
-            int_test!($type, i32);
-            int_test!($type, i64);
-            int_test!($type, i128);
-            int_test!($type, isize);
+            test!($type, u8);
+            test!($type, u16);
+            test!($type, u32);
+            test!($type, u64);
+            test!($type, u128);
+            test!($type, usize);
+
+            test!($type, i8);
+            test!($type, i16);
+            test!($type, i32);
+            test!($type, i64);
+            test!($type, i128);
+            test!($type, isize);
+
+            test!($type, f32);
+            test!($type, f64);
+        }
+    };
+}
+
+macro_rules! float_tests {
+    ($type:ident) => {
+        #[test]
+        fn $type() {
+            test!($type, u8);
+            test!($type, u16);
+            test!($type, u32);
+            test!($type, u64);
+            test!($type, u128);
+            test!($type, usize);
+
+            test!($type, i8);
+            test!($type, i16);
+            test!($type, i32);
+            test!($type, i64);
+            test!($type, i128);
+            test!($type, isize);
+
+            test!($type, f32);
+            test!($type, f64);
         }
     };
 }
@@ -45,3 +73,6 @@ int_tests!(i32);
 int_tests!(i64);
 int_tests!(i128);
 int_tests!(isize);
+
+float_tests!(f32);
+float_tests!(f64);


### PR DESCRIPTION
Adds the following implementations:
- `ApproxEq<{float} for {integer}`
- `ApproxEq<{integer}> for {float}`

Also includes a major rewrite of tests to make them more general for a
given type.